### PR TITLE
CallableTaskletBatch 예제 추가

### DIFF
--- a/src/main/kotlin/com/hoon/batch/job/CallableTaskletBatch.kt
+++ b/src/main/kotlin/com/hoon/batch/job/CallableTaskletBatch.kt
@@ -1,0 +1,35 @@
+package com.hoon.batch.job
+
+import org.springframework.batch.core.Step
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory
+import org.springframework.batch.core.step.tasklet.CallableTaskletAdapter
+import org.springframework.batch.repeat.RepeatStatus
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class CallableTaskletBatch(
+    private val jobBuilderFactory: JobBuilderFactory,
+    private val stepBuilderFactory: StepBuilderFactory
+) {
+
+    @Bean
+    fun callableTaskletJob(
+        callableStep: Step
+    ) = jobBuilderFactory.get("callableTaskletBatch")
+        .start(callableStep)
+        .build()
+
+    @Bean
+    fun callableStep() = stepBuilderFactory.get("callableStep")
+        .tasklet(tasklet())
+        .build()
+
+    private fun tasklet(): CallableTaskletAdapter = CallableTaskletAdapter().apply {
+        this.setCallable {
+            print("This was executed in another thread")
+            RepeatStatus.FINISHED
+        }
+    }
+}

--- a/src/test/kotlin/com/hoon/batch/job/CallableTaskletBatchTest.kt
+++ b/src/test/kotlin/com/hoon/batch/job/CallableTaskletBatchTest.kt
@@ -1,0 +1,26 @@
+package com.hoon.batch.job
+
+import com.hoon.batch.BatchTestConfig
+import io.kotlintest.shouldBe
+import org.junit.jupiter.api.Test
+import org.springframework.batch.core.ExitStatus
+import org.springframework.batch.test.JobLauncherTestUtils
+import org.springframework.batch.test.context.SpringBatchTest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ContextConfiguration
+
+@ContextConfiguration(classes = [BatchTestConfig::class, CallableTaskletBatch::class])
+@SpringBatchTest
+class CallableTaskletBatchTest @Autowired constructor(
+    val jobLauncherTestUtils: JobLauncherTestUtils
+) {
+
+    @Test
+    fun `CallableTaskletBatch 성공`() {
+        val jobParameters = jobLauncherTestUtils.uniqueJobParametersBuilder
+            .toJobParameters()
+        val jobExecution = jobLauncherTestUtils.launchJob(jobParameters)
+
+        jobExecution.exitStatus shouldBe ExitStatus.COMPLETED
+    }
+}


### PR DESCRIPTION
CallableTasklet은 스텝이 실행되는 스레드와 별개의 스레드에서 실행되지만 그렇다고 해서 스텝과 병렬로 실행되는 것은 아니다.