### PR TITLE
system command tasklet 구현

### DIFF
--- a/src/main/kotlin/com/hoon/batch/job/CallableTaskletBatchConfiguration.kt
+++ b/src/main/kotlin/com/hoon/batch/job/CallableTaskletBatchConfiguration.kt
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-class CallableTaskletBatch(
+class CallableTaskletBatchConfiguration(
     private val jobBuilderFactory: JobBuilderFactory,
     private val stepBuilderFactory: StepBuilderFactory
 ) {

--- a/src/main/kotlin/com/hoon/batch/job/HelloWorldBatchConfiguration.kt
+++ b/src/main/kotlin/com/hoon/batch/job/HelloWorldBatchConfiguration.kt
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-class HelloWorldBatch(
+class HelloWorldBatchConfiguration(
     private val jobBuilderFactory: JobBuilderFactory,
     private val stepBuilderFactory: StepBuilderFactory
 ) {

--- a/src/main/kotlin/com/hoon/batch/job/SystemCommandTaskletBatchConfiguration.kt
+++ b/src/main/kotlin/com/hoon/batch/job/SystemCommandTaskletBatchConfiguration.kt
@@ -1,0 +1,40 @@
+package com.hoon.batch.job
+
+import org.springframework.batch.core.Step
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory
+import org.springframework.batch.core.step.tasklet.SimpleSystemProcessExitCodeMapper
+import org.springframework.batch.core.step.tasklet.SystemCommandTasklet
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.task.SimpleAsyncTaskExecutor
+
+@Configuration
+class SystemCommandTaskletBatchConfiguration(
+    private val jobBuilderFactory: JobBuilderFactory,
+    private val stepBuilderFactory: StepBuilderFactory
+) {
+
+    @Bean
+    fun systemCommandJob(
+        systemCommandStep: Step
+    ) = jobBuilderFactory.get("systemCommandJob")
+        .start(systemCommandStep)
+        .build()
+
+    @Bean
+    fun systemCommandStep() = stepBuilderFactory.get("systemCommandStep")
+        .tasklet(systemCommandTasklet())
+        .build()
+
+    private fun systemCommandTasklet() = SystemCommandTasklet().apply {
+        this.setWorkingDirectory("/Users")
+        this.setCommand("ls -al")
+        this.setTimeout(5000)
+        this.setInterruptOnCancel(true)
+        this.setTerminationCheckInterval(5000)
+        this.setTaskExecutor(SimpleAsyncTaskExecutor())
+        this.setEnvironmentParams(arrayOf("BATCH_HOME=/Users/batch"))
+        this.setSystemProcessExitCodeMapper(SimpleSystemProcessExitCodeMapper())
+    }
+}

--- a/src/test/kotlin/com/hoon/batch/job/CallableTaskletBatchTest.kt
+++ b/src/test/kotlin/com/hoon/batch/job/CallableTaskletBatchTest.kt
@@ -9,7 +9,7 @@ import org.springframework.batch.test.context.SpringBatchTest
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.ContextConfiguration
 
-@ContextConfiguration(classes = [BatchTestConfig::class, CallableTaskletBatch::class])
+@ContextConfiguration(classes = [BatchTestConfig::class, CallableTaskletBatchConfiguration::class])
 @SpringBatchTest
 class CallableTaskletBatchTest @Autowired constructor(
     val jobLauncherTestUtils: JobLauncherTestUtils

--- a/src/test/kotlin/com/hoon/batch/job/HelloWorldBatchTest.kt
+++ b/src/test/kotlin/com/hoon/batch/job/HelloWorldBatchTest.kt
@@ -9,7 +9,7 @@ import org.springframework.batch.test.context.SpringBatchTest
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.ContextConfiguration
 
-@ContextConfiguration(classes = [BatchTestConfig::class, HelloWorldBatch::class])
+@ContextConfiguration(classes = [BatchTestConfig::class, HelloWorldBatchConfiguration::class])
 @SpringBatchTest
 class HelloWorldBatchTest @Autowired constructor(
     val jobLauncherTestUtils: JobLauncherTestUtils

--- a/src/test/kotlin/com/hoon/batch/job/SystemCommandTaskletBatchTest.kt
+++ b/src/test/kotlin/com/hoon/batch/job/SystemCommandTaskletBatchTest.kt
@@ -1,0 +1,26 @@
+package com.hoon.batch.job
+
+import com.hoon.batch.BatchTestConfig
+import io.kotlintest.shouldBe
+import org.junit.jupiter.api.Test
+import org.springframework.batch.core.ExitStatus
+import org.springframework.batch.test.JobLauncherTestUtils
+import org.springframework.batch.test.context.SpringBatchTest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ContextConfiguration
+
+@ContextConfiguration(classes = [BatchTestConfig::class, SystemCommandTaskletBatchConfiguration::class])
+@SpringBatchTest
+class SystemCommandTaskletBatchTest @Autowired constructor(
+    val jobLauncherTestUtils: JobLauncherTestUtils
+) {
+
+    @Test
+    fun `SystemCommandTaskletBatch 성공`() {
+        val jobParameters = jobLauncherTestUtils.uniqueJobParametersBuilder
+            .toJobParameters()
+        val jobExecution = jobLauncherTestUtils.launchJob(jobParameters)
+
+        jobExecution.exitStatus shouldBe ExitStatus.COMPLETED
+    }
+}


### PR DESCRIPTION
시스템 명령어는 비동기로 실행되므로 timeout을 설정해줘야 한다.
# systemProcessExitCodeMapper
시스템 반환 코드를 스프링 배치 상태값으로 매핑할 수 있음
스프링이 제공하는 기본 구현체는 2가지
* ConfigurableSystemProcessExitCodeMapper
*  SimpleSystemProcessExitCodeMapper 
# terminateCheckInterval
비동기 방식으로 시스템 명령을 실행하기 때문에 태스크릿이 해당 명령의 완료 여부를 주기적으로 확인해야한다.
기본값은 1초
# taskExecutor
시스템 명령을 실행하는 TaskExecutor
동기식으로 구성하면 시스템 명령 시 문제가 발생했을 때 lock이 걸릴 수 있다.