### PR TITLE
conditional batch

### DIFF
--- a/src/main/kotlin/com/hoon/batch/job/ConditionalBatchConfiguration.kt
+++ b/src/main/kotlin/com/hoon/batch/job/ConditionalBatchConfiguration.kt
@@ -1,0 +1,76 @@
+package com.hoon.batch.job
+
+import org.springframework.batch.core.Step
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory
+import org.springframework.batch.core.configuration.annotation.StepScope
+import org.springframework.batch.core.step.tasklet.Tasklet
+import org.springframework.batch.repeat.RepeatStatus
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class ConditionalBatchConfiguration(
+    private val jobBuilderFactory: JobBuilderFactory,
+    private val stepBuilderFactory: StepBuilderFactory
+) {
+
+    @Bean
+    fun conditionalJob(
+        divideStep: Step,
+        successStep: Step,
+        failureStep: Step
+    ) = jobBuilderFactory.get("conditionalJob")
+        .start(divideStep)
+        .on("FAILED").to((failureStep))
+        .from(divideStep).on("*").to(successStep)
+        .end()
+        .build()
+
+    @Bean
+    fun divideStep(
+        divideTasklet: Tasklet
+    ) = stepBuilderFactory.get("divideStep")
+        .tasklet(divideTasklet)
+        .build()
+
+    @Bean
+    fun successStep(
+        successTasklet: Tasklet
+    ) = stepBuilderFactory.get("successStep")
+        .tasklet(successTasklet)
+        .build()
+
+    @Bean
+    fun failureStep(
+        failureTasklet: Tasklet
+    ) = stepBuilderFactory.get("failureStep")
+        .tasklet(failureTasklet)
+        .build()
+
+    @Bean
+    @StepScope
+    fun divideTasklet() = Tasklet { _, chunkContext ->
+        val divisor = chunkContext.stepContext
+            .stepExecution
+            .jobExecution
+            .jobParameters
+            .getLong("divisor")!!
+        println(5/divisor)
+        RepeatStatus.FINISHED
+    }
+
+    @Bean
+    fun successTasklet(
+
+    ) = Tasklet { _, _ ->
+        println("Success!")
+        RepeatStatus.FINISHED
+    }
+
+    @Bean
+    fun failureTasklet() = Tasklet { _, _ ->
+        println("Failure!")
+        RepeatStatus.FINISHED
+    }
+}

--- a/src/test/kotlin/com/hoon/batch/job/ChunkBasedBatchTest.kt
+++ b/src/test/kotlin/com/hoon/batch/job/ChunkBasedBatchTest.kt
@@ -18,7 +18,7 @@ class ChunkBasedBatchTest @Autowired constructor(
 ) {
 
     @Test
-    fun `CunkBasedBatch 성공`() {
+    fun `ChunkBasedBatch 성공`() {
         val jobParameters = jobLauncherTestUtils.uniqueJobParametersBuilder
             .toJobParameters()
         val jobExecution = jobLauncherTestUtils.launchJob(jobParameters)

--- a/src/test/kotlin/com/hoon/batch/job/ConditionalBatchTest.kt
+++ b/src/test/kotlin/com/hoon/batch/job/ConditionalBatchTest.kt
@@ -1,0 +1,39 @@
+package com.hoon.batch.job
+
+import com.hoon.batch.BatchTestConfig
+import io.kotlintest.shouldBe
+import org.junit.jupiter.api.Test
+import org.springframework.batch.core.ExitStatus
+import org.springframework.batch.test.JobLauncherTestUtils
+import org.springframework.batch.test.context.SpringBatchTest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ContextConfiguration
+
+@ContextConfiguration(classes = [BatchTestConfig::class, ConditionalBatchConfiguration::class])
+@SpringBatchTest
+class ConditionalBatchTest @Autowired constructor(
+    val jobLauncherTestUtils: JobLauncherTestUtils
+) {
+
+    @Test
+    fun `ConditionalBatch 성공`() {
+        val jobParameters = jobLauncherTestUtils.uniqueJobParametersBuilder
+            .addLong("divisor", 5)
+            .toJobParameters()
+        val jobExecution = jobLauncherTestUtils.launchJob(jobParameters)
+
+        jobExecution.stepExecutions.any { it.exitStatus.exitCode.equals(ExitStatus.FAILED.exitCode) } shouldBe false
+        jobExecution.exitStatus shouldBe ExitStatus.COMPLETED
+    }
+
+    @Test
+    fun `ConditionalBatch 실패`() {
+        val jobParameters = jobLauncherTestUtils.uniqueJobParametersBuilder
+            .addLong("divisor", 0)
+            .toJobParameters()
+        val jobExecution = jobLauncherTestUtils.launchJob(jobParameters)
+
+        jobExecution.stepExecutions.any { it.exitStatus.exitCode.equals(ExitStatus.FAILED.exitCode) } shouldBe true
+        jobExecution.exitStatus shouldBe ExitStatus.COMPLETED
+    }
+}


### PR DESCRIPTION
# 설명
divide step 이 정상적으로 수행되면 successStep을 실행, 오류가 발생하면 ExitStatus.FAILED를 반환하고 failureStep을 실행
# 참고
스프링 배치는 다음에 어떤 스탭을 수행할지 결정하기 위해 ExitStatus를 확인
ExitStatus는 문자열이기 때문에 와일드 카드를 사용할 수 있음
*는 0개 이상의 문자를 match시킴 ex) C* -> COMPLETE, CORRECT를 match
?는 1개의 문자를 match ex) ?AT -> CAT, KAT은 match, THAT은 not match
