### PR TITLE
job exitStatus

### DIFF
--- a/src/main/kotlin/com/hoon/batch/job/ConditionalBatchConfiguration.kt
+++ b/src/main/kotlin/com/hoon/batch/job/ConditionalBatchConfiguration.kt
@@ -26,7 +26,7 @@ class ConditionalBatchConfiguration(
         exitStatusDecider: JobExecutionDecider
     ) = jobBuilderFactory.get("conditionalJob")
         .start(divideStep).on("*").to(exitStatusDecider)
-        .from(exitStatusDecider).on("FAILED").to((failureStep))
+        .from(exitStatusDecider).on("FAILED").to((failureStep)).on("*").fail()
         .from(exitStatusDecider).on("*").to(successStep)
         .end()
         .build()

--- a/src/test/kotlin/com/hoon/batch/job/ConditionalBatchTest.kt
+++ b/src/test/kotlin/com/hoon/batch/job/ConditionalBatchTest.kt
@@ -34,6 +34,6 @@ class ConditionalBatchTest @Autowired constructor(
         val jobExecution = jobLauncherTestUtils.launchJob(jobParameters)
 
         jobExecution.stepExecutions.any { it.exitStatus.exitCode.equals(ExitStatus.FAILED.exitCode) } shouldBe true
-        jobExecution.exitStatus shouldBe ExitStatus.COMPLETED
+        jobExecution.exitStatus shouldBe ExitStatus.FAILED
     }
 }


### PR DESCRIPTION
# 설명
Job Instance의 종료상태는 3가지가 있음
* Completed - 동일 파라미터로 배치 재실행 불가
* Failed - 동일 파라미터로 배치 재실행 가능
* Stopped - 동일 파라미터로 배치 재실행 가능하며 중단된 위치에서 다시 시작 가능. 스텝 사이에 사람의 개입 또는 다른 처리가 필요한 경우 유용함

Job Instance의 종료상태를 변경하기 위해서는 builder에서 failed로 끝나도록 구성해야 함