### PR TITLE
flow batch test

### DIFF
--- a/src/main/kotlin/com/hoon/batch/job/FlowBatchConfiguration.kt
+++ b/src/main/kotlin/com/hoon/batch/job/FlowBatchConfiguration.kt
@@ -16,14 +16,23 @@ class FlowBatchConfiguration(
     private val stepBuilderFactory: StepBuilderFactory
 ) {
 
+//    @Bean
+//    fun conditionalStepLogicJob(
+//        preProcessingFlow: Flow,
+//        runBatch: Step
+//    ) = jobBuilderFactory.get("conditionalStepLogicJob")
+//        .start(preProcessingFlow)
+//        .next(runBatch)
+//        .end()
+//        .build()
+
     @Bean
     fun conditionalStepLogicJob(
-        preProcessingFlow: Flow,
+        initializeBatch: Step,
         runBatch: Step
     ) = jobBuilderFactory.get("conditionalStepLogicJob")
-        .start(preProcessingFlow)
+        .start(initializeBatch)
         .next(runBatch)
-        .end()
         .build()
 
     @Bean
@@ -35,6 +44,13 @@ class FlowBatchConfiguration(
         .start(loadFileStep)
         .next(loadCustomerStep)
         .next(updateStartStep)
+        .build()
+
+    @Bean
+    fun initializeBatch(
+        preProcessingFlow: Flow
+    ) = stepBuilderFactory.get("initializeBatch")
+        .flow(preProcessingFlow)
         .build()
 
     @Bean


### PR DESCRIPTION
# 내용
flow를 jobBuilder로 전달하는 것과 flow step을 사용하는 것에는 차이가 있다.
* jobBuilder를 사용하면 job에 step을 구성하는 것과 결과적으로 동일
* flow step을 사용하면 flow가 담긴 step을 하나의 step처럼 기록

집계가 쉬워지기 때문에 모니터링과 리포팅을 하기 좋아짐.